### PR TITLE
Add Bulk Upload Page

### DIFF
--- a/app/Filament/App/Pages/BulkUploadPage.php
+++ b/app/Filament/App/Pages/BulkUploadPage.php
@@ -43,7 +43,14 @@ class BulkUploadPage extends Page implements HasForms
                     ->hint('If you have the policy document(s), please upload them here.')
                     ->required()
                     ->multiple()
-                    // Question: do we need to restrict file types? e.g. MS Word, text file, etc?
+                    // restrict file types to pdf, MS Word, text file
+                    ->acceptedFileTypes([
+                        'application/pdf',
+                        'application/x-pdf',
+                        'application/msword',
+                        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                        'text/plain',
+                        ]) 
                     ->preserveFilenames()
                     // when storedFiles(false) is called, the $this->form->getState() will return an array of TemporaryUploadedFile objects 
                     // instead of an array of paths to the stored files

--- a/app/Filament/App/Pages/BulkUploadPage.php
+++ b/app/Filament/App/Pages/BulkUploadPage.php
@@ -2,13 +2,15 @@
 
 namespace App\Filament\App\Pages;
 
-use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Pages\Page;
 use Filament\Actions\Action;
+use App\Models\PolicyDocument;
+use Filament\Facades\Filament;
 use Filament\Support\Exceptions\Halt;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
+use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Concerns\InteractsWithForms;
 use App\Filament\App\Resources\PolicyDocumentResource;
 
@@ -36,15 +38,18 @@ class BulkUploadPage extends Page implements HasForms
     {
         return $form
             ->schema([
-                Forms\Components\SpatieMediaLibraryFileUpload::make('documents')
+                FileUpload::make('documents')
                     ->label('Upload Policy Document(s)')
                     ->hint('If you have the policy document(s), please upload them here.')
+                    ->required()
                     ->multiple()
-                    ->reorderable()
+                    // Question: do we need to restrict file types? e.g. MS Word, text file, etc?
                     ->preserveFilenames()
-                    ->collection('policy-documents'),
-        ])
-        ->statePath('data');
+                    // when storedFiles(false) is called, the $this->form->getState() will return an array of TemporaryUploadedFile objects 
+                    // instead of an array of paths to the stored files
+                    ->storeFiles(false),
+            ])
+            ->statePath('data');
     }
 
     // define actions
@@ -61,30 +66,51 @@ class BulkUploadPage extends Page implements HasForms
     public function save(): void
     {
         try {
-            // cannot access the uploaded files
-            // in this custom page, we did not bind file upload component to any Laravel model yet...
-            // do we need to relate the uploaded files to a Laravel model for successful upload?
-            // 
-            // Question: how to access the uploaded file in the submitted form?
+            // get submitted form
             $data = $this->form->getState();
-            ray($data);
 
-            // TODO: create one policy document model for each uploaded file
+            // get the uploaded files from submitted form
+            $documents = $data['documents'];
+
+            // create one policy document model for each uploaded file
+            foreach ($documents as $document) {
+                // create policy document model, set original file name
+                $policyDocument = PolicyDocument::create([
+                    'assessment_id' => Filament::getTenant()->id,
+                    'name' => $document->getClientOriginalName(),
+                ]);
+
+                // add the uploaded file to policy document model
+                $policyDocument->addMedia($document->getRealPath())->toMediaCollection('policy-documents');
+
+                // save policy document model
+                $policyDocument->save();
+
+                // get all uploaded file of the saved policy document
+                $medias = $policyDocument->getMedia('policy-documents');
+
+                // set original file name to media record
+                // only need to update the first item because one policy document has one uploaded file only
+                $medias[0]->name = $document->getClientOriginalName();
+                $medias[0]->file_name = $document->getClientOriginalName();
+                $medias[0]->save();                
+            }
+
+            // redirect to policy documents list page
+            redirect(PolicyDocumentResource::getUrl('index'));
+
+            // hardcode temporary for testing
+            $numberOfFiles = count($documents);
+
+            // show notification
+            Notification::make() 
+                ->success()
+                ->title($numberOfFiles . ' file uploaded and ' . $numberOfFiles . ' policy documents created')
+                ->send(); 
  
         } catch (Halt $exception) {
             return;
         }
 
-        // TODO: redirect to policy documents list page
-        // redirect(PolicyDocumentResource::getUrl('index'));
-
-        // hardcode temporary for testing
-        $numberOfFiles = 3;
-
-        // show notification
-        Notification::make() 
-            ->success()
-            ->title($numberOfFiles . ' file uploaded and 3 policy documents created')
-            ->send(); 
     }
 }

--- a/app/Filament/App/Pages/BulkUploadPage.php
+++ b/app/Filament/App/Pages/BulkUploadPage.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Filament\App\Pages;
+
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Pages\Page;
+use Filament\Actions\Action;
+use Filament\Support\Exceptions\Halt;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Forms\Concerns\InteractsWithForms;
+use App\Filament\App\Resources\PolicyDocumentResource;
+
+class BulkUploadPage extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    // declare array to store submitted form data
+    public ?array $data = []; 
+
+    protected static ?string $navigationIcon = 'heroicon-o-arrow-up-on-square-stack';
+
+    protected static ?string $title = 'Bulk Upload';
+
+    // define custom page blade view file location
+    protected static string $view = 'filament.app.pages.bulk-upload-page';
+
+    public function mount(): void 
+    {
+        $this->form->fill();
+    }
+ 
+    // define form components
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\SpatieMediaLibraryFileUpload::make('documents')
+                    ->label('Upload Policy Document(s)')
+                    ->hint('If you have the policy document(s), please upload them here.')
+                    ->multiple()
+                    ->reorderable()
+                    ->preserveFilenames()
+                    ->collection('policy-documents'),
+        ])
+        ->statePath('data');
+    }
+
+    // define actions
+    protected function getFormActions(): array
+    {
+        return [
+            Action::make('save')
+                ->label(__('filament-panels::resources/pages/edit-record.form.actions.save.label'))
+                ->submit('save'),
+        ];
+    }
+
+    // define what to do when user clicked Save button
+    public function save(): void
+    {
+        try {
+            // cannot access the uploaded files
+            // in this custom page, we did not bind file upload component to any Laravel model yet...
+            // do we need to relate the uploaded files to a Laravel model for successful upload?
+            // 
+            // Question: how to access the uploaded file in the submitted form?
+            $data = $this->form->getState();
+            ray($data);
+
+            // TODO: create one policy document model for each uploaded file
+ 
+        } catch (Halt $exception) {
+            return;
+        }
+
+        // TODO: redirect to policy documents list page
+        // redirect(PolicyDocumentResource::getUrl('index'));
+
+        // hardcode temporary for testing
+        $numberOfFiles = 3;
+
+        // show notification
+        Notification::make() 
+            ->success()
+            ->title($numberOfFiles . ' file uploaded and 3 policy documents created')
+            ->send(); 
+    }
+}

--- a/app/Filament/App/Resources/PolicyDocumentResource.php
+++ b/app/Filament/App/Resources/PolicyDocumentResource.php
@@ -66,6 +66,14 @@ class PolicyDocumentResource extends Resource
                                 ->reorderable()
                                 ->downloadable()
                                 ->preserveFilenames()
+                                // restrict file types to pdf, MS Word, text file
+                                ->acceptedFileTypes([
+                                    'application/pdf',
+                                    'application/x-pdf',
+                                    'application/msword',
+                                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                                    'text/plain',
+                                    ]) 
                                 // keep this file upload component enabled, so that user can delete the uploaded file
                                 ->filterMediaUsing(
                                     function (Collection $media, Get $get) {

--- a/app/Filament/App/Resources/PolicyDocumentResource.php
+++ b/app/Filament/App/Resources/PolicyDocumentResource.php
@@ -40,20 +40,20 @@ class PolicyDocumentResource extends Resource
                     // the origninal file upload component
                     // it will be replaced by another two file upload components later
                     // TODO: remove this file upload component when finish testing Editable Documents and Non Editable Documents file upload components
-                    Forms\Components\Section::make('Documents')
-                        ->columnSpan(1)
-                        ->schema([
-                            Forms\Components\SpatieMediaLibraryFileUpload::make('documents')
-                                ->label('Upload Policy Document(s)')
-                                ->hint('If you have the policy document(s), please upload them here.')
-                                ->multiple()
-                                ->reorderable()
-                                ->preserveFilenames()
-                                ->collection('policy-documents'),
-                            Forms\Components\TextInput::make('url')
-                                ->label('URL to Policy Document(s)')
-                                ->hint('If you do not have the policy document(s), please provide the URL to the document(s) online'),
-                        ]),
+                    // Forms\Components\Section::make('Documents')
+                    //     ->columnSpan(1)
+                    //     ->schema([
+                    //         Forms\Components\SpatieMediaLibraryFileUpload::make('documents')
+                    //             ->label('Upload Policy Document(s)')
+                    //             ->hint('If you have the policy document(s), please upload them here.')
+                    //             ->multiple()
+                    //             ->reorderable()
+                    //             ->preserveFilenames()
+                    //             ->collection('policy-documents'),
+                    //         Forms\Components\TextInput::make('url')
+                    //             ->label('URL to Policy Document(s)')
+                    //             ->hint('If you do not have the policy document(s), please provide the URL to the document(s) online'),
+                    //     ]),
 
                     // file upload component to show files that can be deleted (files without any highlight)
                     Forms\Components\Section::make('Editable Documents')
@@ -64,6 +64,7 @@ class PolicyDocumentResource extends Resource
                                 ->hint('If you have the policy document(s), please upload them here.')
                                 ->multiple()
                                 ->reorderable()
+                                ->downloadable()
                                 ->preserveFilenames()
                                 // keep this file upload component enabled, so that user can delete the uploaded file
                                 ->filterMediaUsing(
@@ -81,7 +82,7 @@ class PolicyDocumentResource extends Resource
                         ]),
 
                     // file upload component to show files that cannot be deleted (files with any highlight)
-                    Forms\Components\Section::make('Non Editedable Documents')
+                    Forms\Components\Section::make('Non Editable Documents')
                         ->columnSpan(1)
                         ->schema([
                             Forms\Components\SpatieMediaLibraryFileUpload::make('non_editable_documents')
@@ -89,6 +90,7 @@ class PolicyDocumentResource extends Resource
                                 ->hint('There are highlights in these uploaded documents, therefore they cannot be deleted')
                                 ->multiple()
                                 ->reorderable()
+                                ->downloadable()
                                 ->preserveFilenames()
                                 // keep this file upload component disabled, so that user cannot delete the uploaded file
                                 ->disabled()

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Filament\App\Pages\AssessmentOverview;
+use App\Filament\App\Pages\BulkUploadPage;
 use App\Filament\App\Pages\RegisterAssessment;
 use App\Filament\App\Pages\Review;
 use App\Filament\App\Resources\PolicyDocumentResource;
@@ -76,6 +77,7 @@ class AppPanelProvider extends PanelProvider
                     ->items([
                         ...AssessmentOverview::getNavigationItems(),
                         ...PolicyDocumentResource::getNavigationItems(),
+                        ...BulkUploadPage::getNavigationItems(),
                         ...Review::getNavigationItems(),
                         NavigationItem::make('Admin Panel')
                             ->icon('heroicon-o-shield-check')

--- a/resources/views/filament/app/pages/bulk-upload-page.blade.php
+++ b/resources/views/filament/app/pages/bulk-upload-page.blade.php
@@ -1,0 +1,25 @@
+<x-filament-panels::page>
+
+    <!-- user instructions -->
+    <x-filament::section
+        class="mb-4"
+        heading="Page information"
+        icon="heroicon-o-information-circle"
+        icon-color="primary"
+        collapsible>
+        <p class="mb-4">This page is for bulk upload. Each uploaded file will become a new policy document.</p>
+    </x-filament::section>
+
+
+    <!-- wire form submission to call save() function in custom page -->
+    <x-filament-panels::form wire:submit="save">
+
+        <!-- show filament form defined in form() function custom page -->
+        {{ $this->form }}
+
+        <!-- show filament actions (buttons) defined in getFormActions() function custom page -->
+        <x-filament-panels::form.actions :actions="$this->getFormActions()"/> 
+
+    </x-filament-panels::form>
+
+</x-filament-panels::page>


### PR DESCRIPTION
This PR is submitted to fix https://github.com/stats4sd/ae-policy-tracking-tool/issues/8

This is to add a custom page for bulk upload policy document files.
One policy document model will be created for each uploaded file.

It is not yet ready for review. It is submitted for progress update.

---

It contains below changes:
 - [x] Add custom page for bulk upload
 - [x] Access uploaded files in submitted form, create policy document model for each uploaded file
 - [x] Redirect to policy document resource list page after form submission
 - [x] Show notification to inform user how many policy documents have been created
 - [x] app panel, add "Bulk Upload" to top bar

---

Screen shots:

<img width="1920" height="982" alt="image" src="https://github.com/user-attachments/assets/214bc9f1-6933-4e09-8661-e4b770e96c6b" />

<img width="1920" height="982" alt="image" src="https://github.com/user-attachments/assets/e8615443-4b67-45b5-9447-bc019f2ae166" />
