### PR TITLE
Update Dependencies

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -270,16 +270,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.372.1",
+            "version": "3.372.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "a48ff951eaad7f038eca3e0e89f168048b99082b"
+                "reference": "d1885c8c5db03c2a23121e6df58ef5693df41b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a48ff951eaad7f038eca3e0e89f168048b99082b",
-                "reference": "a48ff951eaad7f038eca3e0e89f168048b99082b",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d1885c8c5db03c2a23121e6df58ef5693df41b95",
+                "reference": "d1885c8c5db03c2a23121e6df58ef5693df41b95",
                 "shasum": ""
             },
             "require": {
@@ -361,9 +361,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.372.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.372.2"
             },
-            "time": "2026-03-06T21:27:21+00:00"
+            "time": "2026-03-09T18:21:50+00:00"
         },
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -2696,16 +2696,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "718f1ee6a878be5290af3557aeda0c91278361d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/718f1ee6a878be5290af3557aeda0c91278361d9",
+                "reference": "718f1ee6a878be5290af3557aeda0c91278361d9",
                 "shasum": ""
             },
             "require": {
@@ -2792,7 +2792,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.8.1"
             },
             "funding": [
                 {
@@ -2808,7 +2808,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-03-10T09:55:26+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",


### PR DESCRIPTION
This PR is submitted to update dependencies.

Here is what I did:

I run command "composer audit", it found 4 security vulnerability.
I run command "composer update", dependencies updated.
I run command "composer audit" again, it has no security vulnerability.

---

```
dan@dan-XPS-9320:~/Sites/ae-policy-tracking-tool$ composer audit
Found 4 security vulnerability advisories affecting 4 packages:
+-------------------+----------------------------------------------------------------------------------+
| Package           | league/commonmark                                                                |
| Severity          | medium                                                                           |
| CVE               | CVE-2026-30838                                                                   |
| Title             | CommonMark has DisallowedRawHtml extension bypass via whitespace in HTML tag     |
|                   | names                                                                            |
| URL               | https://github.com/advisories/GHSA-4v6x-c7xx-hw9f                                |
| Affected versions | <=2.8.0                                                                          |
| Reported at       | 2026-03-06T23:27:03+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | phpunit/phpunit                                                                  |
| Severity          | high                                                                             |
| CVE               | CVE-2026-24765                                                                   |
| Title             | PHPUnit Vulnerable to Unsafe Deserialization in PHPT Code Coverage Handling      |
| URL               | https://github.com/advisories/GHSA-vvj3-c3rp-c85p                                |
| Affected versions | >=12.0.0,<12.5.8|>=11.0.0,<11.5.50|>=10.0.0,<10.5.62|>=9.0.0,<9.6.33|<8.5.52     |
| Reported at       | 2026-01-27T22:26:22+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | psy/psysh                                                                        |
| Severity          | medium                                                                           |
| CVE               | CVE-2026-25129                                                                   |
| Title             | PsySH has Local Privilege Escalation via CWD .psysh.php auto-load                |
| URL               | https://github.com/advisories/GHSA-4486-gxhx-5mg7                                |
| Affected versions | <=0.11.22|>=0.12.0,<=0.12.18                                                     |
| Reported at       | 2026-01-30T21:28:44+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | symfony/process                                                                  |
| Severity          | medium                                                                           |
| CVE               | CVE-2026-24739                                                                   |
| Title             | Symfony's incorrect argument escaping under MSYS2/Git Bash can lead to           |
|                   | destructive file operations on Windows                                           |
| URL               | https://github.com/advisories/GHSA-r39x-jcww-82v6                                |
| Affected versions | >=8.0,<8.0.5|>=7.4,<7.4.5|>=7.3,<7.3.11|>=6.4,<6.4.33|<5.4.51                    |
| Reported at       | 2026-01-28T21:28:10+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
dan@dan-XPS-9320:~/Sites/ae-policy-tracking-tool$ 
```

---

```
dan@dan-XPS-9320:~/Sites/ae-policy-tracking-tool$ composer audit
No security vulnerability advisories found.
dan@dan-XPS-9320:~/Sites/ae-policy-tracking-tool$

```