### PR TITLE
Add handling to identify title and contents pages (to ignore for auto search)

### DIFF
--- a/app/Console/Commands/MigrateExtractsToPages.php
+++ b/app/Console/Commands/MigrateExtractsToPages.php
@@ -52,6 +52,7 @@ class MigrateExtractsToPages extends Command
                     'policy_document_id' => $document->id,
                     'page_number' => $page['page'],
                     'content' => $page['text'],
+                    'page_type' => $page['page_type'] ?? 'unknown',
                 ]);
             }
 

--- a/app/Enums/PageType.php
+++ b/app/Enums/PageType.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum PageType: string implements HasColor, HasLabel
+{
+    case Title = 'title';
+    case Contents = 'contents';
+    case Body = 'body';
+    case Unknown = 'unknown';
+
+    public function getLabel(): ?string
+    {
+        return match ($this) {
+            self::Title => 'Title',
+            self::Contents => 'Contents',
+            self::Body => 'Body',
+            self::Unknown => 'Unknown',
+        };
+    }
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::Title => 'warning',
+            self::Contents => 'warning',
+            self::Body => 'success',
+            self::Unknown => 'gray',
+        };
+    }
+}

--- a/app/Jobs/PolicyDocumentAutoSearchForPriorityAction.php
+++ b/app/Jobs/PolicyDocumentAutoSearchForPriorityAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Enums\PageType;
 use App\Models\Extract;
 use App\Models\PolicyDocument;
 use App\Models\PolicyDocumentPage;
@@ -23,7 +24,10 @@ class PolicyDocumentAutoSearchForPriorityAction implements ShouldQueue
     public function handle(): void
     {
         $this->priorityAction->loadMissing('searchTerms');
-        $pages = $this->policyDocument->pages()->orderBy('page_number')->get();
+        $pages = $this->policyDocument->pages()
+            ->whereNotIn('page_type', [PageType::Title->value, PageType::Contents->value])
+            ->orderBy('page_number')
+            ->get();
 
         foreach ($pages as $page) {
             $this->searchPage($page);

--- a/app/Jobs/PolicyDocumentExtractContent.php
+++ b/app/Jobs/PolicyDocumentExtractContent.php
@@ -45,6 +45,7 @@ class PolicyDocumentExtractContent implements ShouldQueue
                 'policy_document_id' => $this->policyDocument->id,
                 'page_number' => $page['page'],
                 'content' => $page['text'],
+                'page_type' => $page['page_type'] ?? 'unknown',
             ]);
         }
     }

--- a/app/Models/PolicyDocumentPage.php
+++ b/app/Models/PolicyDocumentPage.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\PageType;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -15,6 +16,11 @@ class PolicyDocumentPage extends Model
         'policy_document_id',
         'page_number',
         'content',
+        'page_type',
+    ];
+
+    protected $casts = [
+        'page_type' => PageType::class,
     ];
 
     protected static function booted(): void

--- a/database/migrations/2026_05_01_140000_add_page_type_to_policy_document_pages_table.php
+++ b/database/migrations/2026_05_01_140000_add_page_type_to_policy_document_pages_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Enums\PageType;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('policy_document_pages', function (Blueprint $table) {
+            $table->string('page_type')->default(PageType::Unknown->value)->after('content');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('policy_document_pages', function (Blueprint $table) {
+            $table->dropColumn('page_type');
+        });
+    }
+};

--- a/scripts/extract_with_pymupdf.py
+++ b/scripts/extract_with_pymupdf.py
@@ -21,9 +21,10 @@ TITLE_MAX_WORD_COUNT = 60       # A title page must have fewer words than this
 # Table-of-contents detection
 TOC_MAX_PAGE_NUMBER = 25        # Only consider pages up to this number as TOC pages
 
-# A TOC-pattern line ends with: 3+ dots then a number, or 3+ spaces then a number
+# A TOC-pattern line ends with: 3+ dots then a number, or 3+ spaces then a number.
+## The number might be followed by one or more | if the contents has been rendered out as a markdown table
 _TOC_LINE_PATTERN = re.compile(
-    r'.{5,}(?:\.{3,}|\s{3,})\s*\d{1,4}\s*$',
+    r'.{5,}(?:\.{3,}|\s{3,})\s*\d{1,4}\s*\|*\s*$',
     re.MULTILINE,
 )
 
@@ -70,7 +71,7 @@ def classify_page(text: str, page_number: int) -> str:
         if len(words) < TITLE_MAX_WORD_COUNT:
             return 'title'
 
-    return 'unknown'
+    return 'body'
 
 
 def sanitize_text(text: str) -> str:

--- a/scripts/extract_with_pymupdf.py
+++ b/scripts/extract_with_pymupdf.py
@@ -7,11 +7,76 @@ import sys
 import pymupdf.layout
 import pymupdf4llm
 
+# ---------------------------------------------------------------------------
+# Page classification thresholds — tune these to adjust sensitivity.
+# The classifier is intentionally conservative: pages are only classified as
+# 'title' or 'contents' when the evidence is clear; everything else is
+# 'unknown' so it is still included in keyword searches.
+# ---------------------------------------------------------------------------
+
+# Title page detection
+TITLE_MAX_PAGE_NUMBER = 3       # Only consider pages up to this number as title pages
+TITLE_MAX_WORD_COUNT = 60       # A title page must have fewer words than this
+
+# Table-of-contents detection
+TOC_MAX_PAGE_NUMBER = 25        # Only consider pages up to this number as TOC pages
+
+# A TOC-pattern line ends with: 3+ dots then a number, or 3+ spaces then a number
+_TOC_LINE_PATTERN = re.compile(
+    r'.{5,}(?:\.{3,}|\s{3,})\s*\d{1,4}\s*$',
+    re.MULTILINE,
+)
+
+# Heading that explicitly names the page as a table of contents
+_TOC_HEADING_PATTERN = re.compile(
+    r'^\s*#*\s*(table\s+of\s+)?contents\s*$',
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Without a "Contents" heading: require this many matching lines AND this ratio
+TOC_MIN_MATCHING_LINES = 6      # Minimum number of TOC-pattern lines
+TOC_MIN_LINE_RATIO = 0.35       # Minimum fraction of non-empty lines that match
+
+# With a "Contents" heading present: lower bar (heading is strong evidence)
+TOC_MIN_MATCHING_LINES_WITH_HEADING = 3
+
+
+def classify_page(text: str, page_number: int) -> str:
+    """Return 'title', 'contents', or 'unknown' for a single page.
+
+    Page numbers are 1-indexed.  Biased toward 'unknown' — only classify
+    when the evidence clearly matches a title or contents page.
+    """
+    # --- Table of contents (checked first — a TOC heading overrides a low word count) ---
+    if page_number <= TOC_MAX_PAGE_NUMBER:
+        non_empty_lines = [ln for ln in text.splitlines() if ln.strip()]
+        toc_lines = _TOC_LINE_PATTERN.findall(text)
+        has_heading = bool(_TOC_HEADING_PATTERN.search(text))
+
+        if has_heading:
+            if len(toc_lines) >= TOC_MIN_MATCHING_LINES_WITH_HEADING:
+                return 'contents'
+        else:
+            if (
+                len(non_empty_lines) > 0
+                and len(toc_lines) >= TOC_MIN_MATCHING_LINES
+                and len(toc_lines) / len(non_empty_lines) >= TOC_MIN_LINE_RATIO
+            ):
+                return 'contents'
+
+    # --- Title page (checked after TOC so a low-word-count TOC isn't mis-labelled) ---
+    if page_number <= TITLE_MAX_PAGE_NUMBER:
+        words = text.split()
+        if len(words) < TITLE_MAX_WORD_COUNT:
+            return 'title'
+
+    return 'unknown'
+
 
 def sanitize_text(text: str) -> str:
     """Replace unprintable/PUA Unicode characters with a standard bullet point."""
     # Private Use Area: U+E000–U+F8FF (includes dingbat font bullets like U+F0B7)
-    return re.sub(r'[\uE000-\uF8FF]', '•', text)
+    return re.sub(r'[-]', '•', text)
 
 
 def extract_text(file_path: str, lang: str = 'eng') -> str:
@@ -34,10 +99,17 @@ def extract_pages(file_path: str, lang: str = 'eng') -> list[dict]:
         ocr_language=lang
         )
 
-    return [
-        {"page": i + 1, "text": sanitize_text(chunk["text"])}
-        for i, chunk in enumerate(chunks)
-    ]
+    pages = []
+    for i, chunk in enumerate(chunks):
+        page_number = i + 1
+        text = sanitize_text(chunk["text"])
+        pages.append({
+            "page": page_number,
+            "text": text,
+            "page_type": classify_page(text, page_number),
+        })
+
+    return pages
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds heuristics to try and automatically identify title and contents pages. These will often have keywords, but will not be relevant for actually using as extracts to evidence the assessment result. So, if we can identify them, we can not search those pages when searching for extracts. 

